### PR TITLE
Add GoReleaser config file

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,6 @@
+version: 2
+archives:
+  - strip_binary_directory: true
+    format_overrides:
+      - goos: windows
+        formats: ["zip"]


### PR DESCRIPTION
This allows using zip archives instead of tar.gz for Windows builds